### PR TITLE
Fix k3s stateful set handling

### DIFF
--- a/clusters/default/applications/aws-ebs-csi-driver.yaml
+++ b/clusters/default/applications/aws-ebs-csi-driver.yaml
@@ -1,0 +1,40 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: aws-ebs-csi-driver
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  project: default
+  source:
+    repoURL: https://kubernetes-sigs.github.io/aws-ebs-csi-driver
+    chart: aws-ebs-csi-driver
+    targetRevision: 2.30.0
+    helm:
+      values: |
+        controller:
+          serviceAccount:
+            create: true
+            name: ebs-csi-controller-sa
+        node:
+          serviceAccount:
+            create: true
+            name: ebs-csi-node-sa
+        storageClasses:
+          - name: gp3
+            annotations:
+              storageclass.kubernetes.io/is-default-class: "true"
+            parameters:
+              type: gp3
+            reclaimPolicy: Retain
+            volumeBindingMode: WaitForFirstConsumer
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kube-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/clusters/default/kustomization.yaml
+++ b/clusters/default/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - applications/cert-manager.yaml
   - applications/cluster-issuer.yaml
   - applications/external-dns.yaml
+  - applications/aws-ebs-csi-driver.yaml


### PR DESCRIPTION
Add AWS EBS CSI Driver with a default gp3 StorageClass via Argo CD to enable persistent storage for StatefulSets.

---
<a href="https://cursor.com/background-agent?bcId=bc-7c13211d-35e9-47e2-b3b4-c6f8c520930f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7c13211d-35e9-47e2-b3b4-c6f8c520930f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

